### PR TITLE
New Intercom widget does not work with 'boot'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,8 @@ export default class Intercom extends Component {
     window.intercomSettings = { ...otherProps, app_id: appID };
 
     if (window.Intercom) {
-      window.Intercom('boot', otherProps);
+      window.Intercom('reattach_activator');
+      window.Intercom('update', props);
     }
   }
 


### PR DESCRIPTION
The new widget does not work properly when you call 'boot' on loading.
Using 'reattach_activator' + 'update' props resolve this. #18 
