### PR TITLE
Resolves issue #18 - Fix for IntercomAPI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,13 @@ const canUseDOM = !!(
   window.document && window.document.createElement)
 );
 
-export let IntercomAPI = (canUseDOM && window.Intercom) || function() { console.warn('Intercom not initialized yet') };
+export const IntercomAPI = (...args) => {
+  if (canUseDOM && window.Intercom) {
+    window.Intercom.apply(null, args);
+  } else {
+    console.warn('Intercom not initialized yet');
+  }
+};
 
 export default class Intercom extends Component {
   static propTypes = {
@@ -37,7 +43,6 @@ export default class Intercom extends Component {
         };
         w.Intercom = i;
         s = d.createElement('script');
-        s.onload = function() { IntercomAPI = window.Intercom };
         s.async = 1;
         s.src = 'https://widget.intercom.io/widget/' + id;
         x = d.getElementsByTagName('script')[0];


### PR DESCRIPTION
When updating to the latest version of the Intercom messenger, my reference to IntercomAPI stopped working in our app. Same issue as reported in #18. What I discovered was that the `.onload` function on line 40 was no longer setting the `IntercomAPI` variable to the actual instance of `window.Intercom`. Instead, it was just setting `IntercomAPI = i`. I think this issue cropped up because the Intercom script is loaded in two stages now. The first script that gets loaded, doesn't appear to set `window.Intercom`, so the code was doing that prematurely.

As a solution, instead of depending on the onload event, I just updated the `IntercomAPI` export to be a function that passes through to `window.Intercom` assuming that the Intercom script has successfully initialized. It should accomplish the same thing as before, but be more maintainable long term should Intercom change their script behavior again. 