### PR TITLE
Use 'prop-types' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "babel-cli": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
-    "babel-preset-stage-0": "^6.1.18"
+    "babel-preset-stage-0": "^6.1.18",
+    "prop-types": "15.5.8"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 const canUseDOM = !!(
   (typeof window !== 'undefined' &&
   window.document && window.document.createElement)


### PR DESCRIPTION
React is deprecating the bundled PropTypes and moving them to a separate package, this causes a lot of deprecation warnings being logged to the console for all dependencies that use bundled PropTypes