### PR TITLE
Requires appID attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,7 @@ export const IntercomAPI = (...args) => {
 
 export default class Intercom extends Component {
   static propTypes = {
-    appID: PropTypes.string,
-    app_id: PropTypes.string
+    appID: PropTypes.string.isRequired,
   };
 
   static displayName = 'Intercom';


### PR DESCRIPTION
Prevents using appId or app_id, or forgetting the attribute

e.g. https://github.com/nhagen/react-intercom/issues/15#issuecomment-297803490