### PR TITLE
Fix for testing with enzyme

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,7 @@ export default class Intercom extends Component {
         s = d.createElement('script');
         s.async = 1;
         s.src = 'https://widget.intercom.io/widget/' + id;
-        x = d.getElementsByTagName('script')[0];
-        x.parentNode.insertBefore(s, x);
+        d.head.appendChild(s);
       })(window, document, appID);
     }
 


### PR DESCRIPTION
When running component tests using enzyme, the following error occurs:
```
TypeError: Cannot read property 'parentNode' of undefined
      
      at node_modules/react-intercom/lib/index.js:73:10
```

This fix resolves this issue.