### PR TITLE
Call shutdown on logout to clear conversations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,13 @@ export default class Intercom extends Component {
     window.intercomSettings = { ...otherProps, app_id: appID };
 
     if (window.Intercom) {
-      window.Intercom('update', otherProps);
+      if (this.loggedIn(this.props) && !this.loggedIn(nextProps)) {
+        // Shutdown and boot each time the user logs out to clear conversations
+        window.Intercom('shutdown');
+        window.Intercom('boot', otherProps);
+      } else {
+        window.Intercom('update', otherProps);
+      }
     }
   }
 
@@ -81,6 +87,10 @@ export default class Intercom extends Component {
     window.Intercom('shutdown');
 
     delete window.Intercom;
+  }
+
+  loggedIn(props) {
+    return props.email || props.user_id;
   }
 
   render() {


### PR DESCRIPTION
In order to end a session in a single-page app, Intercom requires that you call `Intercom('shutdown')`. This clears the session data and particularly the conversations for that user. On a shared computer, this prevents someone else from coming to the website logged-out and seeing the previous user's Intercom conversations in the Messenger. This requirement is documented [here in Intercom's docs](https://developers.intercom.com/v2.0/docs/integrate-intercom-in-a-single-page-app#section-how-to-end-a-session).

This branch makes an addition to call `shutdown` anytime a user logs out (`email` or `user_id` go from defined to undefined) and then immediately calls `boot` again with the new data to bring the Messenger back again for logged-out visitors (if you have that Intercom feature turned on).

I tested this in our application and it's working as expected. Conversations are cleared on logout and the Messenger re-appears for visitors.