### PR TITLE
Declare IntercomAPI to prevent TypeScript warning

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { Component } from 'react';
+import { IntercomAPI } from './src';
 
 export interface IReactIntercomProps {
   appID: string;
@@ -6,3 +7,5 @@ export interface IReactIntercomProps {
 }
 
 export default class Intercom extends Component<IReactIntercomProps> {}
+
+export declare const IntercomAPI;


### PR DESCRIPTION
Warning - 

```
ts] Module '"/node_modules/react-intercom/index"' has no exported member 'IntercomAPI'.
```