### PR TITLE
Notify Intercom of URL changes in SPAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ IntercomAPI('trackEvent', 'invited-friend');
 ```
 
 This is, of course, equivalent to just calling `window.Intercom('trackEvent', 'invited-friend');` or even `Intercom('trackEvent', 'invited-friend');`.
+
+## Tell Intercom when your URL changes
+For single paged apps or pages where the URL changes without a full page reload, you will need to pass the **locationKey** prop in order to initiate a "ping" every time a URL changes. Alternatively, you can call `IntercomAPI('update')` or `window.Intercom('update')`.
+
+
+```js
+render () {
+  // location could come from react-router or the router of your choice
+  const { appUser, location } = this.props;
+
+  const user = {
+    user_id: appUser.id,
+    email: appUser.email,
+    name: appUser.name
+  };
+
+  return (
+    <div className="app">
+  	  <Intercom appID="az33rewf" locationKey={location.pathname} { ...user } />
+    </div>
+  );
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export const IntercomAPI = (...args) => {
 export default class Intercom extends Component {
   static propTypes = {
     appID: PropTypes.string.isRequired,
+    locationKey: PropTypes.string
   };
 
   static displayName = 'Intercom';
@@ -25,6 +26,7 @@ export default class Intercom extends Component {
 
     const {
       appID,
+      locationKey,
       ...otherProps,
     } = props;
 
@@ -59,6 +61,7 @@ export default class Intercom extends Component {
   componentWillReceiveProps(nextProps) {
     const {
       appID,
+      locationKey,
       ...otherProps,
     } = nextProps;
 
@@ -73,6 +76,9 @@ export default class Intercom extends Component {
         window.Intercom('boot', otherProps);
       } else {
         window.Intercom('update', otherProps);
+      }
+      if (locationKey !== this.props.locationKey) {
+        window.Intercom('update');
       }
     }
   }


### PR DESCRIPTION
From the [Intercom docs](https://www.intercom.com/help/install-on-your-product-or-site/other-ways-to-get-started/integrate-intercom-in-a-single-page-app#tell-intercom-when-your-data-or-url-changes)

> For single paged apps or pages where the URL changes without a full page reload, the Intercom Messenger does not automatically send URL changes to Intercom to match messages based on URLs. You will need to call Intercom("update") in order to initiate a "ping" every time a URL changes. 

Without this, Intercom won't be able to track page views correctly, or dispatch automated messages based on URL triggers.

@nhagen :)