### PR TITLE
feat(typedef): add export IntercomAPI in the typedef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,3 +6,4 @@ export interface IReactIntercomProps {
 }
 
 export default class Intercom extends Component<IReactIntercomProps> {}
+export function IntercomAPI(...args): void;


### PR DESCRIPTION
@nhagen Here's an attempt to close issue  #58 - Thanks @jakemmarsh for adding the `index.d.ts` in the PR #52 - It seems that one exported member has been left out, and this PR includes it.

This is a non-breaking change PR. It's also an important addition for Typescript users that currently see the error when trying to: `import { IntercomAPI } from 'react-intercom'`:

[ts] Module "react-intercom/index" has no exported member 'IntercomAPI'. 

Even though the `IntercomAPI` is being exported in the `index.js`, it was not being exported in the `index.d.ts`. This PR adds `IntercomAPI` in the definition file.

@pingshunhuang Hopefully you'll be able to use `react-intercom` in your Typescript projects soon when this PR is merged.