### PR TITLE
Update hide_default_launcher to match official Intercom API

### DIFF
--- a/src/react-intercom.ts
+++ b/src/react-intercom.ts
@@ -57,7 +57,7 @@ interface ReactIntercomProps extends ReactIntercomDataAttributes {
   horizontal_padding?: Number;
   vertical_padding?: Number;
   custom_launcher_selector?: string;
-  hide_default_launcher?: string;
+  hide_default_launcher?: boolean;
   session_duration?: string;
   action_color?: string;
   background_color?: string;


### PR DESCRIPTION
This Pull Request seeks to resolve a type incompatibility between this library and the official Intercom API.

[As seen here](https://user-images.githubusercontent.com/3358672/67281498-d32f2280-f4cf-11e9-84c3-61d47539eeb0.jpg); when attempting to use the `hide_default_launcher` on version `2.0.0-alpha.1` we are met with the following type incompatibility:

```
Type '{ hide_default_launcher: boolean; }' is not assignable to type 'ReactIntercomProps'.
  Types of property 'hide_default_launcher' are incompatible.
    Type 'boolean' is not assignable to type 'string | undefined'.
```

According to the [official Intercom documentation](https://developers.intercom.com/installing-intercom/docs/javascript-api-attributes-objects); `hide_default_launcher` should be of type `boolean`, not `string`.