### PR TITLE
fix: relay IntecomAPI secondary arguments

### DIFF
--- a/src/intercomAPI.ts
+++ b/src/intercomAPI.ts
@@ -1,6 +1,6 @@
-export default function(method: string, ...args: Array<any>) {
+export default function(...args: [string, ...Array<any>]) {
   if (window.Intercom) {
-    window.Intercom.apply(null, [method, args]);
+    window.Intercom.apply(null, args);
   } else {
     console.warn('Intercom not initialized yet');
   }


### PR DESCRIPTION
Currently the secondary arguments of `IntercomAPI` in `2.0` get passed through as an array, meaning that e.g. `onShow` and `onHide` won't work. I.e.

```js
window.Intercom.apply(null, [method, args]);
```
Should be:
```js
window.Intercom.apply(null, [method, ...args]);
```

However, with the above fix `npm run build` throws an error:
```
Error: '__spreadArrays' is not exported by tslib
```

This may be solvable by updating the correct packages. Alternatively, the code can be written as it is in this pull request or something like:
```js
export default function(method: string, ...args: Array<any>) {
  if (window.Intercom) {
    args.unshift(method);
    window.Intercom.apply(null, args);
  } else {
    console.warn('Intercom not initialized yet');
  }
}
```
