### PR TITLE
Surpress the componentWillReceiveProps deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export default class Intercom extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const {
       appID,
       ...otherProps,


### PR DESCRIPTION
UNSAFE_componentWillReceiveProps will replace componentWillReceiveProps more details: https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate

The fix is only a temporary solution to the problem. The actual issue should be fixed by rewriting the component as a functional component later on. This way you can get rid of the deprecated lifecycle events and replace them with React Hooks.